### PR TITLE
Add listing credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To run against a local Minikube:
 And to create a credential:
 ```
 curl -Ss -v \
-    http://localhost:8000/v4/organizations/foobar/credentials \
+    http://localhost:8000/v4/organizations/foobar/credentials/ \
     -d '{
             "provider": "aws",
             "aws": {

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ curl -Ss -i \
             "aws": {
                 "roles": {
                     "admin": "this-is-a-fake-admin-arn",
-                    "awsoperator": "this-is-a-fake-admin-arn"
+                    "awsoperator": "this-is-a-fake-awsoperator-arn"
                 }
             }
         }'

--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ credentiald manages credentials for cloud environments.
 ## Development
 
 To run against a local Minikube:
+
 ```
-./credentiald daemon \
+$ kubectl create namespace giantswarm
+$ ./credentiald daemon \
     --service.kubernetes.incluster=false \
     --service.kubernetes.address=https://$(minikube ip):8443 \
     --service.kubernetes.tls.cafile=~/.minikube/ca.crt \
@@ -16,15 +18,21 @@ To run against a local Minikube:
 
 And to create a credential:
 ```
-curl -Ss -v \
-    http://localhost:8000/v4/organizations/foobar/credentials/ \
+curl -Ss -i \
+    http://localhost:8000/v4/organizations/acme/credentials/ \
     -d '{
             "provider": "aws",
             "aws": {
                 "roles": {
-                    "admin": "arn...",
-                    "awsoperator": "arn..."
+                    "admin": "this-is-a-fake-admin-arn",
+                    "awsoperator": "this-is-a-fake-admin-arn"
                 }
             }
-        }' | jq
+        }'
+```
+
+Retrieve credentials for an org:
+
+```
+curl -s -i http://localhost:8000/v4/organizations/acme/credentials/
 ```

--- a/server/endpoint/endpoint.go
+++ b/server/endpoint/endpoint.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/micrologger"
 
 	"github.com/giantswarm/credentiald/server/endpoint/creator"
+	"github.com/giantswarm/credentiald/server/endpoint/lister"
 	"github.com/giantswarm/credentiald/server/middleware"
 	"github.com/giantswarm/credentiald/service"
 )
@@ -18,6 +19,7 @@ type Config struct {
 
 type Endpoint struct {
 	Creator *creator.Endpoint
+	Lister  *lister.Endpoint
 	Version *version.Endpoint
 }
 
@@ -45,6 +47,19 @@ func New(config Config) (*Endpoint, error) {
 		}
 	}
 
+	var listerEndpoint *lister.Endpoint
+	{
+		c := lister.Config{
+			Logger:  config.Logger,
+			Service: config.Service.Lister,
+		}
+
+		listerEndpoint, err = lister.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var versionEndpoint *version.Endpoint
 	{
 		c := version.Config{
@@ -60,6 +75,7 @@ func New(config Config) (*Endpoint, error) {
 
 	endpoint := &Endpoint{
 		Creator: creatorEndpoint,
+		Lister:  listerEndpoint,
 		Version: versionEndpoint,
 	}
 

--- a/server/endpoint/lister/endpoint.go
+++ b/server/endpoint/lister/endpoint.go
@@ -1,0 +1,127 @@
+// Package lister provides the endpoint to retrieve multiple credentials
+package lister
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	kitendpoint "github.com/go-kit/kit/endpoint"
+	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/gorilla/mux"
+
+	"github.com/giantswarm/credentiald/server/middleware"
+	"github.com/giantswarm/credentiald/service/lister"
+)
+
+const (
+	// Method is the HTTP method to act on.
+	Method = "GET"
+	// Name is the name of our endpoint.
+	Name = "lister"
+	// Path is the URI path our endpoint listens to.
+	Path = "/v4/organizations/{organization}/credentials/"
+)
+
+// Config defines which configuration our endpoint expects.
+type Config struct {
+	Logger     micrologger.Logger
+	Middleware *middleware.Middleware
+	Service    *lister.Service
+}
+
+// Endpoint is the actual endpoint data structure.
+type Endpoint struct {
+	logger     micrologger.Logger
+	middleware *middleware.Middleware
+	service    *lister.Service
+}
+
+// New creates a new endpoint with configuration.
+func New(config Config) (*Endpoint, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Service == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Service must not be empty", config)
+	}
+
+	endpoint := &Endpoint{
+		logger:  config.Logger,
+		service: config.Service,
+	}
+
+	return endpoint, nil
+}
+
+// Decoder gets all useful information from a request to the endpoint.
+func (e *Endpoint) Decoder() kithttp.DecodeRequestFunc {
+	return func(ctx context.Context, r *http.Request) (interface{}, error) {
+		vars := mux.Vars(r)
+
+		var request Request
+		request.Organization = vars["organization"]
+
+		return request, nil
+	}
+}
+
+// Encoder creates a response in the specified format.
+func (e *Endpoint) Encoder() kithttp.EncodeResponseFunc {
+	return func(ctx context.Context, w http.ResponseWriter, response interface{}) error {
+		endpointResponse := response.([]*Response)
+
+		w.Header().Set("Content-Type", "application/json")
+		//w.WriteHeader(http.StatusOK)
+
+		return json.NewEncoder(w).Encode(endpointResponse)
+	}
+}
+
+// Endpoint is where requests are handled and responses are returned.
+func (e *Endpoint) Endpoint() kitendpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		e.logger.Log("level", "debug", "message", fmt.Sprintf("received endpoint request: %#v", request))
+
+		endpointRequest := request.(Request)
+
+		serviceRequest := lister.Request{Organization: endpointRequest.Organization}
+		listerResponse, err := e.service.List(serviceRequest)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		e.logger.Log("level", "debug", "message", fmt.Sprintf("received service response: %#v", listerResponse))
+
+		endpointResponse := []*Response{}
+
+		for _, credential := range listerResponse {
+			// TODO: include the actual metadata and role ARNs
+			endpointResponse = append(endpointResponse, &Response{ID: credential.ID})
+		}
+
+		return endpointResponse, nil
+	}
+}
+
+// Method returns the HTTP method supported by this endpoint.
+func (e *Endpoint) Method() string {
+	return Method
+}
+
+// Middlewares returns the middlewares used by this endpoint.
+func (e *Endpoint) Middlewares() []kitendpoint.Middleware {
+	return []kitendpoint.Middleware{}
+}
+
+// Name returns this endpoint's name.
+func (e *Endpoint) Name() string {
+	return Name
+}
+
+// Path returns this endpoint's URI path.
+func (e *Endpoint) Path() string {
+	return Path
+}

--- a/server/endpoint/lister/endpoint.go
+++ b/server/endpoint/lister/endpoint.go
@@ -98,8 +98,27 @@ func (e *Endpoint) Endpoint() kitendpoint.Endpoint {
 		endpointResponse := []*Response{}
 
 		for _, credential := range listerResponse {
-			// TODO: include the actual metadata and role ARNs
-			endpointResponse = append(endpointResponse, &Response{ID: credential.ID})
+			responseItem := &Response{
+				ID:       credential.ID,
+				Provider: credential.Provider,
+			}
+
+			if credential.Provider == "aws" {
+				responseItem.AWS = &ResponseAWS{
+					&ResponseAWSRoles{
+						Admin:       credential.AWS.Roles.Admin,
+						AWSOperator: credential.AWS.Roles.AWSOperator,
+					},
+				}
+			} else if credential.Provider == "azure" {
+				responseItem.Azure = &ResponseAzure{
+					SubscriptionID: credential.Azure.SubscriptionID,
+					TenantID:       credential.Azure.TenantID,
+					ClientID:       credential.Azure.ClientID,
+				}
+			}
+
+			endpointResponse = append(endpointResponse, responseItem)
 		}
 
 		return endpointResponse, nil

--- a/server/endpoint/lister/error.go
+++ b/server/endpoint/lister/error.go
@@ -1,0 +1,14 @@
+package lister
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/server/endpoint/lister/request.go
+++ b/server/endpoint/lister/request.go
@@ -1,0 +1,6 @@
+package lister
+
+// Request is the request the lister service expects.
+type Request struct {
+	Organization string
+}

--- a/server/endpoint/lister/response.go
+++ b/server/endpoint/lister/response.go
@@ -1,7 +1,27 @@
 package lister
 
 // Response is the response format our endpoint will return.
-// TODO: include the actual metadata (aws and azure specific)
 type Response struct {
-	ID string `json:"id"`
+	ID       string         `json:"id"`
+	Provider string         `json:"provider"`
+	AWS      *ResponseAWS   `json:"aws,omitempty"`
+	Azure    *ResponseAzure `json:"azure,omitempty"`
+}
+
+// ResponseAWS is a type used by above Response.
+type ResponseAWS struct {
+	Roles *ResponseAWSRoles `json:"roles"`
+}
+
+// ResponseAWSRoles is a type used by above AWSData struct.
+type ResponseAWSRoles struct {
+	Admin       string `json:"admin"`
+	AWSOperator string `json:"awsoperator"`
+}
+
+// ResponseAzure is a type used by above Response struct.
+type ResponseAzure struct {
+	ClientID       string `json:"client_id"`
+	SubscriptionID string `json:"subscription_id"`
+	TenantID       string `json:"tenant_id"`
 }

--- a/server/endpoint/lister/response.go
+++ b/server/endpoint/lister/response.go
@@ -1,0 +1,7 @@
+package lister
+
+// Response is the response format our endpoint will return.
+// TODO: include the actual metadata (aws and azure specific)
+type Response struct {
+	ID string `json:"id"`
+}

--- a/server/server.go
+++ b/server/server.go
@@ -108,6 +108,7 @@ func (s *Server) Shutdown() {
 	s.shutdownOnce.Do(func() {})
 }
 
+// Here we ensure that certain error types are handled specifically.
 func errorEncoder(ctx context.Context, err error, w http.ResponseWriter) {
 	rErr := err.(microserver.ResponseError)
 	uErr := rErr.Underlying()

--- a/server/server.go
+++ b/server/server.go
@@ -109,7 +109,7 @@ func (s *Server) Shutdown() {
 	s.shutdownOnce.Do(func() {})
 }
 
-// Here we ensure that certain error types are handled specifically.
+// errorEncoder ensures that certain error types are handled specifically.
 func errorEncoder(ctx context.Context, err error, w http.ResponseWriter) {
 	rErr := err.(microserver.ResponseError)
 	uErr := rErr.Underlying()

--- a/server/server.go
+++ b/server/server.go
@@ -86,6 +86,7 @@ func New(config Config) (*Server, error) {
 			Viper:       config.Viper,
 			Endpoints: []microserver.Endpoint{
 				endpointCollection.Creator,
+				endpointCollection.Lister,
 				endpointCollection.Version,
 			},
 			ErrorEncoder: errorEncoder,

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -1,3 +1,4 @@
+// Package collector offers a service to retrieve metrics about credentials.
 package collector
 
 import (
@@ -46,6 +47,7 @@ type Collector struct {
 	logger    micrologger.Logger
 }
 
+// New creates a new Collector based on a configutation.
 func New(config Config) (*Collector, error) {
 	if config.K8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
@@ -63,10 +65,12 @@ func New(config Config) (*Collector, error) {
 	return c, nil
 }
 
+// Describe collects metadata for a prometheus metric.
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- credentials
 }
 
+// Collect collects metrics for prometheus
 func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	c.logger.Log("level", "debug", "message", "collecting metrics")
 

--- a/service/creator/service.go
+++ b/service/creator/service.go
@@ -1,3 +1,4 @@
+// Package creator offers a service to fetch a list of credentials.
 package creator
 
 import (

--- a/service/lister/error.go
+++ b/service/lister/error.go
@@ -1,0 +1,14 @@
+package lister
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/lister/request.go
+++ b/service/lister/request.go
@@ -1,0 +1,6 @@
+package lister
+
+// Request is the request the lister service expects.
+type Request struct {
+	Organization string
+}

--- a/service/lister/response.go
+++ b/service/lister/response.go
@@ -2,5 +2,17 @@ package lister
 
 // Response is the response data structure our lister service will return.
 type Response struct {
-	ID string `json:"id"`
+	ID       string
+	Provider string
+	AWS      struct {
+		Roles struct {
+			Admin       string
+			AWSOperator string
+		}
+	}
+	Azure struct {
+		ClientID       string
+		SubscriptionID string
+		TenantID       string
+	}
 }

--- a/service/lister/response.go
+++ b/service/lister/response.go
@@ -1,0 +1,6 @@
+package lister
+
+// Response is the response data structure our lister service will return.
+type Response struct {
+	ID string `json:"id"`
+}

--- a/service/lister/service.go
+++ b/service/lister/service.go
@@ -1,0 +1,78 @@
+// Package lister offers a service to retrieve credentials for an organization.
+package lister
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// the label we use to identify the owner organization of a secret
+	kubernetesOrganizationLabel = "giantswarm.io/organization"
+
+	// the namespace in which we store credentiald secrets
+	kubernetesCredentialNamespace = "giantswarm"
+
+	// the selector we can use to retrieve credentials
+	// TODO: add organization filter
+	kubernetesLabelSelector = "app=credentiald"
+
+	gaugeValue = float64(1)
+)
+
+// Config is the service configuration data structure.
+type Config struct {
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// Service is our actual service.
+type Service struct {
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new lister service based on a configutation.
+func New(config Config) (*Service, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	service := &Service{
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return service, nil
+}
+
+// List returns metadata on all credentials found.
+func (c *Service) List(request Request) ([]*Response, error) {
+	c.logger.Log("level", "debug", "message", fmt.Sprintf("listing secrets for organization %s", request.Organization))
+
+	// TODO: ensure filtering by org
+	credentialList, err := c.k8sClient.CoreV1().Secrets(kubernetesCredentialNamespace).List(metav1.ListOptions{
+		LabelSelector: kubernetesLabelSelector,
+	})
+	if err != nil {
+		c.logger.Log("level", "error", "message", "could not list secrets", "stack", fmt.Sprintf("%#v", err))
+	}
+
+	resp := []*Response{}
+
+	for _, credential := range credentialList.Items {
+		resp = append(resp, &Response{ID: credential.Name})
+	}
+
+	c.logger.Log("level", "debug", "message", "finished listing secrets")
+
+	return resp, nil
+}


### PR DESCRIPTION
For

- https://github.com/giantswarm/giantswarm/issues/4072
- https://github.com/giantswarm/giantswarm/issues/3987
- Epic: https://github.com/giantswarm/giantswarm/issues/2652

This PR adds an endpoint for listing all credential resources for an organization.

### Preview

```
curl -Ss -i \
    http://localhost:8000/v4/organizations/acme/credentials/ \
    -d '{
            "provider": "aws",
            "aws": {
                "roles": {
                    "admin": "this-is-a-fake-admin-arn",
                    "awsoperator": "this-is-a-fake-awsoperator-arn"
                }
            }
        }'

curl -s http://localhost:8000/v4/organizations/acme/credentials/ | jq .
[
  {
    "id": "y7rqdx",
    "provider": "aws",
    "aws": {
      "roles": {
        "admin": "this-is-a-fake-admin-arn",
        "awsoperator": "this-is-a-fake-awsoperator-arn"
      }
    }
  }
]
```

### TODO

- [x] Cut the ID to remove `credential-`
- [x] Filter by org
- [x] Add more metadata
- [x] Unit test? No