### PR TITLE
Add searcher service and endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ $ kubectl create namespace giantswarm
 $ ./credentiald daemon \
     --service.kubernetes.incluster=false \
     --service.kubernetes.address=https://$(minikube ip):8443 \
-    --service.kubernetes.tls.cafile=~/.minikube/ca.crt \
-    --service.kubernetes.tls.crtfile=~/.minikube/client.crt \
-    --service.kubernetes.tls.keyfile=~/.minikube/client.key
+    --service.kubernetes.tls.cafile=${HOME}/.minikube/ca.crt \
+    --service.kubernetes.tls.crtfile=${HOME}/.minikube/client.crt \
+    --service.kubernetes.tls.keyfile=${HOME}/.minikube/client.key
 ```
 
 And to create a credential:
@@ -35,4 +35,10 @@ Retrieve credentials for an org:
 
 ```
 curl -s -i http://localhost:8000/v4/organizations/acme/credentials/
+```
+
+Retrieve a specific credential (adapt `y13tl7` to an existing ID!)
+
+```
+curl -s -i http://localhost:8000/v4/organizations/giantswarm/credentials/y13tl7/
 ```

--- a/server/endpoint/endpoint.go
+++ b/server/endpoint/endpoint.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/giantswarm/credentiald/server/endpoint/creator"
 	"github.com/giantswarm/credentiald/server/endpoint/lister"
+	"github.com/giantswarm/credentiald/server/endpoint/searcher"
 	"github.com/giantswarm/credentiald/server/middleware"
 	"github.com/giantswarm/credentiald/service"
 )
@@ -18,9 +19,10 @@ type Config struct {
 }
 
 type Endpoint struct {
-	Creator *creator.Endpoint
-	Lister  *lister.Endpoint
-	Version *version.Endpoint
+	Creator  *creator.Endpoint
+	Lister   *lister.Endpoint
+	Searcher *searcher.Endpoint
+	Version  *version.Endpoint
 }
 
 func New(config Config) (*Endpoint, error) {
@@ -60,6 +62,19 @@ func New(config Config) (*Endpoint, error) {
 		}
 	}
 
+	var searcherEndpoint *searcher.Endpoint
+	{
+		c := searcher.Config{
+			Logger:  config.Logger,
+			Service: config.Service.Searcher,
+		}
+
+		searcherEndpoint, err = searcher.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var versionEndpoint *version.Endpoint
 	{
 		c := version.Config{
@@ -74,9 +89,10 @@ func New(config Config) (*Endpoint, error) {
 	}
 
 	endpoint := &Endpoint{
-		Creator: creatorEndpoint,
-		Lister:  listerEndpoint,
-		Version: versionEndpoint,
+		Creator:  creatorEndpoint,
+		Lister:   listerEndpoint,
+		Searcher: searcherEndpoint,
+		Version:  versionEndpoint,
 	}
 
 	return endpoint, nil

--- a/server/endpoint/searcher/endpoint.go
+++ b/server/endpoint/searcher/endpoint.go
@@ -1,0 +1,151 @@
+// Package searcher provides the endpoint to retrieve one credential.
+package searcher
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	kitendpoint "github.com/go-kit/kit/endpoint"
+	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/gorilla/mux"
+
+	"github.com/giantswarm/credentiald/server/middleware"
+	"github.com/giantswarm/credentiald/service/searcher"
+)
+
+const (
+	// Method is the HTTP method to act on.
+	Method = "GET"
+	// Name is the name of our endpoint.
+	Name = "searcher"
+	// Path is the URI path our endpoint listens to.
+	Path = "/v4/organizations/{organization}/credentials/{id}/"
+)
+
+// Config defines which configuration our endpoint expects.
+type Config struct {
+	Logger     micrologger.Logger
+	Middleware *middleware.Middleware
+	Service    *searcher.Service
+}
+
+// Endpoint is the actual endpoint data structure.
+type Endpoint struct {
+	logger     micrologger.Logger
+	middleware *middleware.Middleware
+	service    *searcher.Service
+}
+
+// New creates a new endpoint with configuration.
+func New(config Config) (*Endpoint, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Service == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Service must not be empty", config)
+	}
+
+	endpoint := &Endpoint{
+		logger:  config.Logger,
+		service: config.Service,
+	}
+
+	return endpoint, nil
+}
+
+// Decoder gets all useful information from a request to the endpoint.
+func (e *Endpoint) Decoder() kithttp.DecodeRequestFunc {
+	return func(ctx context.Context, r *http.Request) (interface{}, error) {
+		vars := mux.Vars(r)
+
+		request := Request{
+			Organization: vars["organization"],
+			ID:           vars["id"],
+		}
+
+		return request, nil
+	}
+}
+
+// Encoder creates a response in the specified format.
+func (e *Endpoint) Encoder() kithttp.EncodeResponseFunc {
+	return func(ctx context.Context, w http.ResponseWriter, response interface{}) error {
+		endpointResponse := response.(Response)
+
+		w.Header().Set("Content-Type", "application/json")
+		//w.WriteHeader(http.StatusOK)
+
+		return json.NewEncoder(w).Encode(endpointResponse)
+	}
+}
+
+// Endpoint is where requests are handled and responses are returned.
+func (e *Endpoint) Endpoint() kitendpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		e.logger.Log("level", "debug", "message", fmt.Sprintf("received endpoint request: %#v", request))
+
+		endpointRequest := request.(Request)
+
+		serviceRequest := searcher.Request{
+			Organization: endpointRequest.Organization,
+			ID:           endpointRequest.ID,
+		}
+
+		searcherResponse, err := e.service.Search(serviceRequest)
+		if err != nil {
+			if searcher.IsWrongOwnerOrganizationError(err) {
+				return nil, microerror.Mask(wrongOwnerOrganizationError)
+			} else if searcher.IsSecretNotFoundError(err) {
+				return nil, microerror.Mask(secretNotFoundError)
+			}
+			return nil, microerror.Mask(err)
+		}
+		e.logger.Log("level", "debug", "message", "received searcher response successfully")
+
+		endpointResponse := Response{
+			ID:       searcherResponse.ID,
+			Provider: searcherResponse.Provider,
+		}
+
+		if searcherResponse.Provider == "aws" {
+			endpointResponse.AWS = &ResponseAWS{
+				&ResponseAWSRoles{
+					Admin:       searcherResponse.AWS.Roles.Admin,
+					AWSOperator: searcherResponse.AWS.Roles.AWSOperator,
+				},
+			}
+		} else if searcherResponse.Provider == "azure" {
+			endpointResponse.Azure = &ResponseAzure{
+				SubscriptionID: searcherResponse.Azure.SubscriptionID,
+				TenantID:       searcherResponse.Azure.TenantID,
+				ClientID:       searcherResponse.Azure.ClientID,
+			}
+		}
+
+		return endpointResponse, nil
+	}
+}
+
+// Method returns the HTTP method supported by this endpoint.
+func (e *Endpoint) Method() string {
+	return Method
+}
+
+// Middlewares returns the middlewares used by this endpoint.
+func (e *Endpoint) Middlewares() []kitendpoint.Middleware {
+	return []kitendpoint.Middleware{}
+}
+
+// Name returns this endpoint's name.
+func (e *Endpoint) Name() string {
+	return Name
+}
+
+// Path returns this endpoint's URI path.
+func (e *Endpoint) Path() string {
+	return Path
+}

--- a/server/endpoint/searcher/error.go
+++ b/server/endpoint/searcher/error.go
@@ -1,0 +1,32 @@
+package searcher
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongOwnerOrganizationError = &microerror.Error{
+	Kind: "wrongOwnerOrganizationError",
+}
+
+// IsWrongOwnerOrganizationError asserts wrongOwnerOrganizationError.
+func IsWrongOwnerOrganizationError(err error) bool {
+	return microerror.Cause(err) == wrongOwnerOrganizationError
+}
+
+var secretNotFoundError = &microerror.Error{
+	Kind: "secretNotFoundError",
+}
+
+// IsSecretNotFoundError asserts secretNotFoundError.
+func IsSecretNotFoundError(err error) bool {
+	return microerror.Cause(err) == secretNotFoundError
+}

--- a/server/endpoint/searcher/request.go
+++ b/server/endpoint/searcher/request.go
@@ -1,0 +1,7 @@
+package searcher
+
+// Request is the request the searcher service expects.
+type Request struct {
+	Organization string
+	ID           string
+}

--- a/server/endpoint/searcher/response.go
+++ b/server/endpoint/searcher/response.go
@@ -1,0 +1,27 @@
+package searcher
+
+// Response is the response format our endpoint will return.
+type Response struct {
+	ID       string         `json:"id"`
+	Provider string         `json:"provider"`
+	AWS      *ResponseAWS   `json:"aws,omitempty"`
+	Azure    *ResponseAzure `json:"azure,omitempty"`
+}
+
+// ResponseAWS is a type used by above Response.
+type ResponseAWS struct {
+	Roles *ResponseAWSRoles `json:"roles"`
+}
+
+// ResponseAWSRoles is a type used by above AWSData struct.
+type ResponseAWSRoles struct {
+	Admin       string `json:"admin"`
+	AWSOperator string `json:"awsoperator"`
+}
+
+// ResponseAzure is a type used by above Response struct.
+type ResponseAzure struct {
+	ClientID       string `json:"client_id"`
+	SubscriptionID string `json:"subscription_id"`
+	TenantID       string `json:"tenant_id"`
+}

--- a/server/server.go
+++ b/server/server.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/giantswarm/credentiald/server/endpoint"
 	"github.com/giantswarm/credentiald/server/endpoint/creator"
+	"github.com/giantswarm/credentiald/server/endpoint/searcher"
 	"github.com/giantswarm/credentiald/server/middleware"
 	"github.com/giantswarm/credentiald/service"
 )
@@ -87,6 +88,7 @@ func New(config Config) (*Server, error) {
 			Endpoints: []microserver.Endpoint{
 				endpointCollection.Creator,
 				endpointCollection.Lister,
+				endpointCollection.Searcher,
 				endpointCollection.Version,
 			},
 			ErrorEncoder: errorEncoder,
@@ -118,6 +120,10 @@ func errorEncoder(ctx context.Context, err error, w http.ResponseWriter) {
 		rErr.SetCode(microserver.CodeResourceAlreadyExists)
 		rErr.SetMessage(uErr.Error())
 		w.WriteHeader(http.StatusConflict)
+	} else if searcher.IsWrongOwnerOrganizationError(uErr) || searcher.IsSecretNotFoundError(uErr) {
+		rErr.SetCode(microserver.CodeResourceNotFound)
+		rErr.SetMessage("A credential with that path does not exist")
+		w.WriteHeader(http.StatusNotFound)
 	} else {
 		rErr.SetCode(microserver.CodeInternalError)
 		rErr.SetMessage(uErr.Error())

--- a/service/searcher/error.go
+++ b/service/searcher/error.go
@@ -30,3 +30,13 @@ var secretNotFoundError = &microerror.Error{
 func IsSecretNotFoundError(err error) bool {
 	return microerror.Cause(err) == secretNotFoundError
 }
+
+var secretInUnexpectedFormatError = &microerror.Error{
+	Kind: "secretInUnexpectedFormatError",
+	Desc: "the resource we retrieved does not have the expected format",
+}
+
+// IsSecretInUnexpectedFormatError asserts secretInUnexpectedFormatError.
+func IsSecretInUnexpectedFormatError(err error) bool {
+	return microerror.Cause(err) == secretInUnexpectedFormatError
+}

--- a/service/searcher/error.go
+++ b/service/searcher/error.go
@@ -1,0 +1,32 @@
+package searcher
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongOwnerOrganizationError = &microerror.Error{
+	Kind: "wrongOwnerOrganizationError",
+}
+
+// IsWrongOwnerOrganizationError asserts wrongOwnerOrganizationError.
+func IsWrongOwnerOrganizationError(err error) bool {
+	return microerror.Cause(err) == wrongOwnerOrganizationError
+}
+
+var secretNotFoundError = &microerror.Error{
+	Kind: "secretNotFoundError",
+}
+
+// IsSecretNotFoundError asserts secretNotFoundError.
+func IsSecretNotFoundError(err error) bool {
+	return microerror.Cause(err) == secretNotFoundError
+}

--- a/service/searcher/request.go
+++ b/service/searcher/request.go
@@ -1,0 +1,7 @@
+package searcher
+
+// Request is the request the searcher service expects.
+type Request struct {
+	Organization string
+	ID           string
+}

--- a/service/searcher/response.go
+++ b/service/searcher/response.go
@@ -1,0 +1,18 @@
+package searcher
+
+// Response is the response data structure our searcher service will return.
+type Response struct {
+	ID       string
+	Provider string
+	AWS      struct {
+		Roles struct {
+			Admin       string
+			AWSOperator string
+		}
+	}
+	Azure struct {
+		ClientID       string
+		SubscriptionID string
+		TenantID       string
+	}
+}

--- a/service/searcher/service.go
+++ b/service/searcher/service.go
@@ -1,0 +1,111 @@
+// Package searcher provides functionality to retrieve a single credential.
+package searcher
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// the namespace in which we store credentiald secrets
+	kubernetesCredentialNamespace = "giantswarm"
+
+	// a label we expect to be set to the owner org
+	kubernetesOrganizationLabel = "giantswarm.io/organization"
+
+	gaugeValue = float64(1)
+
+	providerAWS   = "aws"
+	providerAzure = "azure"
+
+	// We use these data keys to detect the provider from a secret.
+	providerAWSDetectionKey   = "aws.admin.arn"
+	providerAzureDetectionKey = "azure.azureoperator.subscriptionid"
+)
+
+// Config is the service configuration data structure.
+type Config struct {
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// Service is our actual service.
+type Service struct {
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new lister service based on a configutation.
+func New(config Config) (*Service, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	service := &Service{
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return service, nil
+}
+
+// Search returns metadata about one credential.
+func (c *Service) Search(request Request) (*Response, error) {
+	c.logger.Log("level", "debug", "message", fmt.Sprintf("searching secret for organization %s, ID %s", request.Organization, request.ID))
+
+	name := "credential-" + request.ID
+	credential, err := c.k8sClient.CoreV1().Secrets(kubernetesCredentialNamespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		c.logger.Log("level", "error", "message", "could not list secrets", "stack", fmt.Sprintf("%#v", err))
+		return nil, microerror.Mask(secretNotFoundError)
+	}
+
+	// make sure the found credential really belongs to the organization indicated
+	if ownerOrganization, ok := credential.Labels[kubernetesOrganizationLabel]; ok {
+		if ownerOrganization != request.Organization {
+			return nil, microerror.Mask(wrongOwnerOrganizationError)
+		}
+	}
+
+	resp := &Response{}
+
+	// get ID from name (ex: 'credential-15iv58')
+	{
+		parts := strings.Split(credential.Name, "-")
+		if len(parts) == 2 {
+			resp.ID = parts[1]
+		} else {
+			c.logger.Log("level", "error", "message", fmt.Sprintf("Invalid secret name found: %q", credential.Name))
+		}
+	}
+
+	// get provider from content
+	if _, ok := credential.Data[providerAWSDetectionKey]; ok {
+		resp.Provider = providerAWS
+	} else if _, ok := credential.Data[providerAzureDetectionKey]; ok {
+		resp.Provider = providerAzure
+	}
+
+	// get payload
+	if resp.Provider == providerAWS {
+		resp.AWS.Roles.Admin = string(credential.Data["aws.admin.arn"])
+		resp.AWS.Roles.AWSOperator = string(credential.Data["aws.awsoperator.arn"])
+	} else if resp.Provider == providerAzure {
+		resp.Azure.SubscriptionID = string(credential.Data["azure.azureoperator.subscriptionid"])
+		resp.Azure.TenantID = string(credential.Data["azure.azureoperator.tenantid"])
+		resp.Azure.ClientID = string(credential.Data["azure.azureoperator.clientid"])
+	}
+
+	c.logger.Log("level", "debug", "message", "finished listing secrets")
+
+	return resp, nil
+}

--- a/service/searcher/service.go
+++ b/service/searcher/service.go
@@ -3,7 +3,6 @@ package searcher
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -79,16 +78,8 @@ func (c *Service) Search(request Request) (*Response, error) {
 		return nil, microerror.Mask(wrongOwnerOrganizationError)
 	}
 
-	resp := &Response{}
-
-	// get ID from name (ex: 'credential-15iv58')
-	{
-		parts := strings.Split(credential.Name, "-")
-		if len(parts) == 2 {
-			resp.ID = parts[1]
-		} else {
-			c.logger.Log("level", "error", "message", fmt.Sprintf("Invalid secret name found: %q", credential.Name))
-		}
+	resp := &Response{
+		ID: request.ID,
 	}
 
 	// get provider from content

--- a/service/searcher/service.go
+++ b/service/searcher/service.go
@@ -92,13 +92,16 @@ func (c *Service) Search(request Request) (*Response, error) {
 	}
 
 	// get payload
-	if resp.Provider == providerAWS {
+	switch resp.Provider {
+	case providerAWS:
 		resp.AWS.Roles.Admin = string(credential.Data["aws.admin.arn"])
 		resp.AWS.Roles.AWSOperator = string(credential.Data["aws.awsoperator.arn"])
-	} else if resp.Provider == providerAzure {
+	case providerAzure:
 		resp.Azure.SubscriptionID = string(credential.Data["azure.azureoperator.subscriptionid"])
 		resp.Azure.TenantID = string(credential.Data["azure.azureoperator.tenantid"])
 		resp.Azure.ClientID = string(credential.Data["azure.azureoperator.clientid"])
+	default:
+		return nil, microerror.Mask(secretInUnexpectedFormatError)
 	}
 
 	c.logger.Log("level", "debug", "message", "finished listing secrets")

--- a/service/searcher/service.go
+++ b/service/searcher/service.go
@@ -87,6 +87,8 @@ func (c *Service) Search(request Request) (*Response, error) {
 		resp.Provider = providerAWS
 	} else if _, ok := credential.Data[providerAzureDetectionKey]; ok {
 		resp.Provider = providerAzure
+	} else {
+		return nil, microerror.Mask(secretInUnexpectedFormatError)
 	}
 
 	// get payload

--- a/service/searcher/service.go
+++ b/service/searcher/service.go
@@ -74,6 +74,9 @@ func (c *Service) Search(request Request) (*Response, error) {
 		if ownerOrganization != request.Organization {
 			return nil, microerror.Mask(wrongOwnerOrganizationError)
 		}
+	} else {
+		// no organization set
+		return nil, microerror.Mask(wrongOwnerOrganizationError)
 	}
 
 	resp := &Response{}


### PR DESCRIPTION
Epic: https://github.com/giantswarm/giantswarm/issues/2652

For https://github.com/giantswarm/giantswarm/issues/4072

This adds the endpoint and service to retrieve a single credential.

### TODO

- [x] if the credential does not contain the owner organization label, return 404