### PR TITLE
Return with error in case k8s listing fails

### DIFF
--- a/service/lister/service.go
+++ b/service/lister/service.go
@@ -68,6 +68,7 @@ func (c *Service) List(request Request) ([]*Response, error) {
 	})
 	if err != nil {
 		c.logger.Log("level", "error", "message", "could not list secrets", "stack", fmt.Sprintf("%#v", err))
+		return nil, microerror.Mask(err)
 	}
 
 	resp := []*Response{}


### PR DESCRIPTION
For: https://github.com/giantswarm/giantswarm/issues/4072

Follow-up PR to improve the error handling in case we can't list secrets via the K8s API.