### PR TITLE
Filter out credential-default from lister

### DIFF
--- a/service/lister/service.go
+++ b/service/lister/service.go
@@ -26,6 +26,8 @@ const (
 	// We use these data keys to detect the provider from a secret.
 	providerAWSDetectionKey   = "aws.admin.arn"
 	providerAzureDetectionKey = "azure.azureoperator.subscriptionid"
+
+	defaultCredentialName = "credential-default"
 )
 
 // Config is the service configuration data structure.
@@ -77,7 +79,7 @@ func (c *Service) List(request Request) ([]*Response, error) {
 		item := &Response{}
 
 		// We never expose the credential-default secret.
-		if credential.Name == "credential-default" {
+		if credential.Name == defaultCredentialName {
 			continue
 		}
 

--- a/service/lister/service.go
+++ b/service/lister/service.go
@@ -76,6 +76,11 @@ func (c *Service) List(request Request) ([]*Response, error) {
 	for _, credential := range credentialList.Items {
 		item := &Response{}
 
+		// We never expose the credential-default secret.
+		if credential.Name == "credential-default" {
+			continue
+		}
+
 		// get ID from name (ex: 'credential-15iv58')
 		{
 			parts := strings.Split(credential.Name, "-")


### PR DESCRIPTION
Epic: https://github.com/giantswarm/giantswarm/issues/2652

This fixes credentiald so that the `credential-default` secret is not returned in any lister requests.

Before this change it is returned when requesting `GET /v4/organizations/giantswarm/credentials/`