### PR TITLE
Respond with 404 on fetching default credential

### DIFF
--- a/service/searcher/service.go
+++ b/service/searcher/service.go
@@ -61,6 +61,12 @@ func New(config Config) (*Service, error) {
 func (c *Service) Search(request Request) (*Response, error) {
 	c.logger.Log("level", "debug", "message", fmt.Sprintf("searching secret for organization %s, ID %s", request.Organization, request.ID))
 
+	// We never expose the credential-default secret. From the outside, this dos not exist.
+	if request.ID == "default" {
+		c.logger.Log("level", "warn", "message", "attempt to get default credential. Denied.")
+		return nil, microerror.Mask(secretNotFoundError)
+	}
+
 	name := "credential-" + request.ID
 	credential, err := c.k8sClient.CoreV1().Secrets(kubernetesCredentialNamespace).Get(name, metav1.GetOptions{})
 	if err != nil {

--- a/service/searcher/service.go
+++ b/service/searcher/service.go
@@ -25,6 +25,9 @@ const (
 	// We use these data keys to detect the provider from a secret.
 	providerAWSDetectionKey   = "aws.admin.arn"
 	providerAzureDetectionKey = "azure.azureoperator.subscriptionid"
+
+	// we name our default credential "credential-default". This is the second part of it.
+	defaultCredentialNameIDPart = "default"
 )
 
 // Config is the service configuration data structure.
@@ -62,7 +65,7 @@ func (c *Service) Search(request Request) (*Response, error) {
 	c.logger.Log("level", "debug", "message", fmt.Sprintf("searching secret for organization %s, ID %s", request.Organization, request.ID))
 
 	// We never expose the credential-default secret. From the outside, this does not exist.
-	if request.ID == "default" {
+	if request.ID == defaultCredentialNameIDPart {
 		c.logger.Log("level", "warn", "message", "attempt to get default credential. Denied.")
 		return nil, microerror.Mask(secretNotFoundError)
 	}

--- a/service/searcher/service.go
+++ b/service/searcher/service.go
@@ -66,7 +66,6 @@ func (c *Service) Search(request Request) (*Response, error) {
 
 	// We never expose the credential-default secret. From the outside, this does not exist.
 	if request.ID == defaultCredentialNameIDPart {
-		c.logger.Log("level", "warn", "message", "attempt to get default credential. Denied.")
 		return nil, microerror.Mask(secretNotFoundError)
 	}
 

--- a/service/searcher/service.go
+++ b/service/searcher/service.go
@@ -61,7 +61,7 @@ func New(config Config) (*Service, error) {
 func (c *Service) Search(request Request) (*Response, error) {
 	c.logger.Log("level", "debug", "message", fmt.Sprintf("searching secret for organization %s, ID %s", request.Organization, request.ID))
 
-	// We never expose the credential-default secret. From the outside, this dos not exist.
+	// We never expose the credential-default secret. From the outside, this does not exist.
 	if request.ID == "default" {
 		c.logger.Log("level", "warn", "message", "attempt to get default credential. Denied.")
 		return nil, microerror.Mask(secretNotFoundError)


### PR DESCRIPTION
Epic: https://github.com/giantswarm/giantswarm/issues/2652

Similar to https://github.com/giantswarm/credentiald/pull/18, for the searcher service