### PR TITLE
Change azure credential response format

### DIFF
--- a/server/endpoint/searcher/endpoint.go
+++ b/server/endpoint/searcher/endpoint.go
@@ -120,9 +120,11 @@ func (e *Endpoint) Endpoint() kitendpoint.Endpoint {
 			}
 		} else if searcherResponse.Provider == "azure" {
 			endpointResponse.Azure = &ResponseAzure{
-				SubscriptionID: searcherResponse.Azure.SubscriptionID,
-				TenantID:       searcherResponse.Azure.TenantID,
-				ClientID:       searcherResponse.Azure.ClientID,
+				Credential: &ResponseAzureCredential{
+					SubscriptionID: searcherResponse.Azure.Credential.SubscriptionID,
+					TenantID:       searcherResponse.Azure.Credential.TenantID,
+					ClientID:       searcherResponse.Azure.Credential.ClientID,
+				},
 			}
 		}
 

--- a/server/endpoint/searcher/response.go
+++ b/server/endpoint/searcher/response.go
@@ -21,6 +21,11 @@ type ResponseAWSRoles struct {
 
 // ResponseAzure is a type used by above Response struct.
 type ResponseAzure struct {
+	Credential *ResponseAzureCredential `json:"credential"`
+}
+
+// ResponseAzureCredential is a type used by above Response struct.
+type ResponseAzureCredential struct {
 	ClientID       string `json:"client_id"`
 	SubscriptionID string `json:"subscription_id"`
 	TenantID       string `json:"tenant_id"`

--- a/service/searcher/response.go
+++ b/service/searcher/response.go
@@ -11,8 +11,10 @@ type Response struct {
 		}
 	}
 	Azure struct {
-		ClientID       string
-		SubscriptionID string
-		TenantID       string
+		Credential struct {
+			ClientID       string
+			SubscriptionID string
+			TenantID       string
+		}
 	}
 }

--- a/service/searcher/service.go
+++ b/service/searcher/service.go
@@ -97,9 +97,9 @@ func (c *Service) Search(request Request) (*Response, error) {
 		resp.AWS.Roles.Admin = string(credential.Data["aws.admin.arn"])
 		resp.AWS.Roles.AWSOperator = string(credential.Data["aws.awsoperator.arn"])
 	case providerAzure:
-		resp.Azure.SubscriptionID = string(credential.Data["azure.azureoperator.subscriptionid"])
-		resp.Azure.TenantID = string(credential.Data["azure.azureoperator.tenantid"])
-		resp.Azure.ClientID = string(credential.Data["azure.azureoperator.clientid"])
+		resp.Azure.Credential.SubscriptionID = string(credential.Data["azure.azureoperator.subscriptionid"])
+		resp.Azure.Credential.TenantID = string(credential.Data["azure.azureoperator.tenantid"])
+		resp.Azure.Credential.ClientID = string(credential.Data["azure.azureoperator.clientid"])
 	default:
 		return nil, microerror.Mask(secretInUnexpectedFormatError)
 	}


### PR DESCRIPTION
Epic: https://github.com/giantswarm/giantswarm/issues/2652, https://github.com/giantswarm/giantswarm/issues/3987

This corrects a mistake I made with a previous PR and adapts the response format for an Azure credential to the specification.

See https://github.com/giantswarm/api-spec/pull/105/files#diff-86c65848dca38faa0e9098f6a682cd02R682