### PR TITLE
Adds metrics for kubernetes latency and errors

### DIFF
--- a/service/creator/metric.go
+++ b/service/creator/metric.go
@@ -1,0 +1,35 @@
+package creator
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	namespace = "credentiald"
+	subsystem = "credentials"
+)
+
+var (
+	createTime = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "create",
+			Help:      "Time taken to create credentials.",
+		},
+	)
+
+	kubernetesCreateErrorTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "kubernetes_create_error_total",
+			Help:      "Counter of errors encountered creating Kubernetes credential secrets.",
+		},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(createTime)
+	prometheus.MustRegister(kubernetesCreateErrorTotal)
+}

--- a/service/lister/metric.go
+++ b/service/lister/metric.go
@@ -1,0 +1,35 @@
+package lister
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	namespace = "credentiald"
+	subsystem = "credentials"
+)
+
+var (
+	listTime = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "list",
+			Help:      "Time taken to list credentials.",
+		},
+	)
+
+	kubernetesListErrorTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "kubernetes_list_error_total",
+			Help:      "Counter of errors encountered listing Kubernetes credential secrets.",
+		},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(listTime)
+	prometheus.MustRegister(kubernetesListErrorTotal)
+}

--- a/service/searcher/metric.go
+++ b/service/searcher/metric.go
@@ -1,0 +1,35 @@
+package searcher
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	namespace = "credentiald"
+	subsystem = "credentials"
+)
+
+var (
+	searchTime = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "search",
+			Help:      "Time taken to search credentials.",
+		},
+	)
+
+	kubernetesSearchErrorTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "kubernetes_search_error_total",
+			Help:      "Counter of errors encountered searching Kubernetes credential secrets.",
+		},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(searchTime)
+	prometheus.MustRegister(kubernetesSearchErrorTotal)
+}

--- a/service/searcher/service.go
+++ b/service/searcher/service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"github.com/prometheus/client_golang/prometheus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -62,6 +63,9 @@ func New(config Config) (*Service, error) {
 
 // Search returns metadata about one credential.
 func (c *Service) Search(request Request) (*Response, error) {
+	timer := prometheus.NewTimer(searchTime)
+	defer timer.ObserveDuration()
+
 	c.logger.Log("level", "debug", "message", fmt.Sprintf("searching secret for organization %s, ID %s", request.Organization, request.ID))
 
 	// We never expose the credential-default secret. From the outside, this does not exist.
@@ -72,7 +76,8 @@ func (c *Service) Search(request Request) (*Response, error) {
 	name := "credential-" + request.ID
 	credential, err := c.k8sClient.CoreV1().Secrets(kubernetesCredentialNamespace).Get(name, metav1.GetOptions{})
 	if err != nil {
-		c.logger.Log("level", "error", "message", "could not list secrets", "stack", fmt.Sprintf("%#v", err))
+		kubernetesSearchErrorTotal.Inc()
+		c.logger.Log("level", "error", "message", "could not get secret", "stack", fmt.Sprintf("%#v", err))
 		return nil, microerror.Mask(secretNotFoundError)
 	}
 
@@ -112,7 +117,7 @@ func (c *Service) Search(request Request) (*Response, error) {
 		return nil, microerror.Mask(secretInUnexpectedFormatError)
 	}
 
-	c.logger.Log("level", "debug", "message", "finished listing secrets")
+	c.logger.Log("level", "debug", "message", "finished getting secret")
 
 	return resp, nil
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4628

We had an error with credentiald where the service could not access Kubernetes secrets due to missing RBAC permissions. This PR adds histograms for the total number of create/list/search operations and their latency, as well as counters for errors accessing secrets in Kubernetes.

```
# HELP credentiald_credentials_create Time taken to create credentials.
# TYPE credentiald_credentials_create histogram
credentiald_credentials_create_bucket{le="0.005"} 0
credentiald_credentials_create_bucket{le="0.01"} 0
credentiald_credentials_create_bucket{le="0.025"} 0
credentiald_credentials_create_bucket{le="0.05"} 0
credentiald_credentials_create_bucket{le="0.1"} 0
credentiald_credentials_create_bucket{le="0.25"} 0
credentiald_credentials_create_bucket{le="0.5"} 0
credentiald_credentials_create_bucket{le="1"} 0
credentiald_credentials_create_bucket{le="2.5"} 0
credentiald_credentials_create_bucket{le="5"} 0
credentiald_credentials_create_bucket{le="10"} 0
credentiald_credentials_create_bucket{le="+Inf"} 0
credentiald_credentials_create_sum 0
credentiald_credentials_create_count 0
# HELP credentiald_credentials_kubernetes_create_error_total Counter of errors encountered creating Kubernetes credential secrets.
# TYPE credentiald_credentials_kubernetes_create_error_total counter
credentiald_credentials_kubernetes_create_error_total 0
# HELP credentiald_credentials_kubernetes_list_error_total Counter of errors encountered listing Kubernetes credential secrets.
# TYPE credentiald_credentials_kubernetes_list_error_total counter
credentiald_credentials_kubernetes_list_error_total 0
# HELP credentiald_credentials_kubernetes_search_error_total Counter of errors encountered searching Kubernetes credential secrets.
# TYPE credentiald_credentials_kubernetes_search_error_total counter
credentiald_credentials_kubernetes_search_error_total 3
# HELP credentiald_credentials_list Time taken to list credentials.
# TYPE credentiald_credentials_list histogram
credentiald_credentials_list_bucket{le="0.005"} 2
credentiald_credentials_list_bucket{le="0.01"} 2
credentiald_credentials_list_bucket{le="0.025"} 2
credentiald_credentials_list_bucket{le="0.05"} 2
credentiald_credentials_list_bucket{le="0.1"} 2
credentiald_credentials_list_bucket{le="0.25"} 2
credentiald_credentials_list_bucket{le="0.5"} 2
credentiald_credentials_list_bucket{le="1"} 2
credentiald_credentials_list_bucket{le="2.5"} 2
credentiald_credentials_list_bucket{le="5"} 2
credentiald_credentials_list_bucket{le="10"} 2
credentiald_credentials_list_bucket{le="+Inf"} 2
credentiald_credentials_list_sum 0.005109464
credentiald_credentials_list_count 2
# HELP credentiald_credentials_search Time taken to search credentials.
# TYPE credentiald_credentials_search histogram
credentiald_credentials_search_bucket{le="0.005"} 3
credentiald_credentials_search_bucket{le="0.01"} 3
credentiald_credentials_search_bucket{le="0.025"} 3
credentiald_credentials_search_bucket{le="0.05"} 3
credentiald_credentials_search_bucket{le="0.1"} 3
credentiald_credentials_search_bucket{le="0.25"} 3
credentiald_credentials_search_bucket{le="0.5"} 3
credentiald_credentials_search_bucket{le="1"} 3
credentiald_credentials_search_bucket{le="2.5"} 3
credentiald_credentials_search_bucket{le="5"} 3
credentiald_credentials_search_bucket{le="10"} 3
credentiald_credentials_search_bucket{le="+Inf"} 3
credentiald_credentials_search_sum 0.002728687
credentiald_credentials_search_count 3
```