### PR TITLE
Returns kubernetes error in case we can't get secret

### DIFF
--- a/service/searcher/service.go
+++ b/service/searcher/service.go
@@ -78,7 +78,7 @@ func (c *Service) Search(request Request) (*Response, error) {
 	if err != nil {
 		kubernetesSearchErrorTotal.Inc()
 		c.logger.Log("level", "error", "message", "could not get secret", "stack", fmt.Sprintf("%#v", err))
-		return nil, microerror.Mask(secretNotFoundError)
+		return nil, microerror.Mask(err)
 	}
 
 	// make sure the found credential really belongs to the organization indicated

--- a/service/searcher/service.go
+++ b/service/searcher/service.go
@@ -73,7 +73,7 @@ func (c *Service) Search(request Request) (*Response, error) {
 	credential, err := c.k8sClient.CoreV1().Secrets(kubernetesCredentialNamespace).Get(name, metav1.GetOptions{})
 	if err != nil {
 		c.logger.Log("level", "error", "message", "could not list secrets", "stack", fmt.Sprintf("%#v", err))
-		return nil, microerror.Mask(secretNotFoundError)
+		return nil, microerror.Mask(err)
 	}
 
 	// make sure the found credential really belongs to the organization indicated


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4628

In case we can't fetch the secret (e.g: due to the RBAC issue I'm fixing next :D ), gsctl output is now:
```
$ gsctl show cluster cx60u
An internal error occurred.
Please try again in a few minutes. If that does not success, please inform the Giant Swarm support team.
```
and the api response is:
```
$ curl -H "Authorization: Bearer $TOKEN" https://api.g8s.gauss.eu-central-1.aws.gigantic.io/v4/organizations/byoc-test/credentials/f7dk39/
{"code":"INTERNAL_ERROR","message":"secrets \"credential-f7dk39\" is forbidden: User \"system:serviceaccount:giantswarm:credentiald\" cannot get secrets in the namespace \"giantswarm\""}
```

the gsctl output previously was:
```
$ gsctl show cluster cx60u
Credential not found
Credentials with the given ID could not be found.
```
which is very misleading