### PR TITLE
Adds rbac permission to get secrets

### DIFF
--- a/helm/credentiald-chart/templates/rbac.yaml
+++ b/helm/credentiald-chart/templates/rbac.yaml
@@ -11,6 +11,7 @@ rules:
       - secrets
     verbs:
       - create
+      - get
       - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4628

We use `Get` in the credential searcher, but the permission was not added to the role. This fixes.

e.g:
```
$ gsctl show cluster cx60u
ID:                        cx60u
Name:                      joe-test
Created:                   2018 Nov 07, 10:31 UTC
Organization:              byoc-test
AWS account:               [is-this-even-sensitive?]
Kubernetes API endpoint:   https://api.cx60u.k8s.gauss.eu-central-1.aws.gigantic.io
Release version:           6.0.0
Workers:                   3
Worker instance type:      m3.large
CPU cores in workers:      6
RAM in worker nodes (GB):  22.50
```