### PR TITLE
helm: add credential-default Secret template

### DIFF
--- a/helm/credentiald-chart/templates/credetnail-default.yaml
+++ b/helm/credentiald-chart/templates/credetnail-default.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: credential-default
+  namespace: giantswarm
+  labels:
+    app: credentiald
+    giantswarm.io/managed-by: credentiald
+    giantswarm.io/organization: giantswarm
+    giantswarm.io/service-type: system
+data:
+  {{ if .Values.Installation.V1.Secret.Credentiald.AWS }}
+  aws.admin.arn: {{ .Values.Installation.V1.Secret.Credentiald.AWS.CredentialDefault.AdminARN | b64enc }}
+  aws.awsoperator.arn: {{ .Values.Installation.V1.Secret.Credentiald.AWS.CredentialDefault.AWSOperatorARN | b64enc }}
+  {{ end }}
+  {{ if .Values.Installation.V1.Secret.Credentiald.Azure }}
+  azure.azureoperator.clientid: {{ .Values.Installation.V1.Secret.Credentiald.Azure.CredentialDefault.ClientID | b64enc }}
+  azure.azureoperator.clientsecret: {{ .Values.Installation.V1.Secret.Credentiald.Azure.CredentialDefault.ClientSecret | b64enc }}
+  azure.azureoperator.subscriptionid: {{ .Values.Installation.V1.Secret.Credentiald.Azure.CredentialDefault.SubscriptionID | b64enc }}
+  azure.azureoperator.tenantid: {{ .Values.Installation.V1.Secret.Credentiald.Azure.CredentialDefault.TenantID | b64enc }}
+  {{ end }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6557

See https://github.com/giantswarm/installations/pull/817.
See https://github.com/giantswarm/aws-operator/pull/1807.
See https://github.com/giantswarm/azure-operator/pull/546.

This can't be deployed with aws-operator or azure-operator chart anymore
as we want to be able to install multiple releases of the same operator at
the same time. That would case conflict when creating credential-default
Secret which for helm is a resource with the same name.

After some discussions we decided to put this here as credentiald also
creates other credential secret. And this one had even
`giantswarm.io/managed-by: credentiald` label.