### PR TITLE
helm/credentiald-chart: expose number of replicas in the value

### DIFF
--- a/helm/credentiald-chart/templates/deployment.yaml
+++ b/helm/credentiald-chart/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: credentiald
 spec:
-  replicas: 2
+  replicas: {{ .Values.deployment.replicas }}
   template:
     metadata:
       labels:
@@ -47,8 +47,8 @@ spec:
               topologyKey: kubernetes.io/hostname
       serviceAccountName: credentiald
       securityContext:
-        runAsUser: {{ .Values.userID }}
-        runAsGroup: {{ .Values.groupID }}
+        runAsUser: {{ .Values.pod.user.id }}
+        runAsGroup: {{ .Values.pod.group.id }}
       containers:
       - name: credentiald
         image: quay.io/giantswarm/credentiald:[[ .SHA ]]

--- a/helm/credentiald-chart/values.yaml
+++ b/helm/credentiald-chart/values.yaml
@@ -1,2 +1,9 @@
-userID: 1000
-groupID: 1000
+deployment:
+  replicas: 2
+
+pod:
+  user:
+    id: 1000
+  group:
+    id: 1000
+

--- a/helm/credentiald-chart/values.yaml
+++ b/helm/credentiald-chart/values.yaml
@@ -6,4 +6,3 @@ pod:
     id: 1000
   group:
     id: 1000
-


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6736.

In our E2E tests we want to install credential secret. In order to
achieve that we can install this chart with number of replicas set to 0.
This will install the secret w/o running service pod to spare some CI
resources.