### PR TITLE
Use namespaceSelector instead of ipBlock

### DIFF
--- a/helm/credentiald-chart/templates/networkpolicy.yaml
+++ b/helm/credentiald-chart/templates/networkpolicy.yaml
@@ -28,8 +28,7 @@ spec:
     - port: 443
       protocol: TCP
     to:
-    - ipBlock:
-        cidr: 10.0.0.0/8
+    - namespaceSelector: {}
   # various operators but only in the same namespace
   - ports:
     - port: 8000


### PR DESCRIPTION
Limiting egress traffic to a port via an `ipBlock` filter doesn't seem to work as intended. Instead, using a `namespaceSelector` to all namespaces allows traffic inside the cluster to 443 but stops it leaving the cluster.