### PR TITLE
Disable credentiald network policy by corrupting the podSelector

### DIFF
--- a/helm/credentiald-chart/templates/networkpolicy.yaml
+++ b/helm/credentiald-chart/templates/networkpolicy.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: credentiald
+      app: DEFUNCT-credentiald
   ingress:
   - ports:
     - port: 8000


### PR DESCRIPTION
We see that access from credentiald to the Kubernetes API doesn't work with this policy in place, so we disable it effectively by modifying the podSelector, until we have a better solution.