### PR TITLE
whitelist traffic to k8s apiserver

### DIFF
--- a/helm/credentiald-chart/templates/networkpolicy.yaml
+++ b/helm/credentiald-chart/templates/networkpolicy.yaml
@@ -23,12 +23,18 @@ spec:
     - namespaceSelector:
         matchLabels:
           name: kube-system
-  # API access
+  # API access - we have to whitelist all private IP ranges
+  # as the apiserver is using host networking.
   - ports:
     - port: 443
       protocol: TCP
     to:
-    - namespaceSelector: {}
+    - ipBlock:
+        cidr: 10.0.0.0/8
+    - ipBlock:
+        cidr: 172.16.0.0/12
+    - ipBlock:
+        cidr: 192.168.0.0/16
   # various operators but only in the same namespace
   - ports:
     - port: 8000

--- a/helm/credentiald-chart/templates/networkpolicy.yaml
+++ b/helm/credentiald-chart/templates/networkpolicy.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: DEFUNCT-credentiald
+      app: credentiald
   ingress:
   - ports:
     - port: 8000


### PR DESCRIPTION
towards giantswarm/giantswarm/issues/7213

using a wildcard namespace selector won't work as this whitelists all pod IPs, but the API server is using host networking. instead, allow access to port 443 on all private ranges - this isn't as secure as just specifying the port/pod combo but it still retains traffic inside the cluster (which is the same effect as the wildcard namespace selector).