### PR TITLE
fix-network-policy

### DIFF
--- a/helm/credentiald-chart/templates/networkpolicy.yaml
+++ b/helm/credentiald-chart/templates/networkpolicy.yaml
@@ -28,6 +28,8 @@ spec:
   - ports:
     - port: 443
       protocol: TCP
+    - port: 6443
+      protocol: TCP
     to:
     - ipBlock:
         cidr: 10.0.0.0/8


### PR DESCRIPTION
on kvm installations, we have k8s api listening on port 6443 so this policy break

maybe something to watch @glitchcrab  for other network policies

towards https://github.com/giantswarm/giantswarm/issues/7555