### PR TITLE
Configure default image registry domain

### DIFF
--- a/helm/credentiald-chart/values.yaml
+++ b/helm/credentiald-chart/values.yaml
@@ -6,3 +6,8 @@ pod:
     id: 1000
   group:
     id: 1000
+
+Installation:
+  V1:
+    Registry:
+      Domain: quay.io


### PR DESCRIPTION
Via https://github.com/giantswarm/credentiald/pull/43 image registry domain was made configurable, but no default value was set, and this broke e2e tests deploying credntiald-char, like azure-operator I was testing giantswarm/azure-operator#603

This PR configures quay.io as default image registry domain.