### PR TITLE
Fix helm3 validation issue on credentiald

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Quotation around secret values.
+
 ## [0.3.1] 2020-06-19
 
 ### Changed

--- a/helm/credentiald/Chart.yaml
+++ b/helm/credentiald/Chart.yaml
@@ -3,5 +3,5 @@ name: credentiald
 description: >-
   credentiald manages credentials for cloud environments.
 home: https://github.com/giantswarm/credentiald
-version: 100.0.0
-appVersion: 100.0.0
+version: [[ .Version ]]
+appVersion: [[ .AppVersion ]]

--- a/helm/credentiald/Chart.yaml
+++ b/helm/credentiald/Chart.yaml
@@ -3,5 +3,5 @@ name: credentiald
 description: >-
   credentiald manages credentials for cloud environments.
 home: https://github.com/giantswarm/credentiald
-version: [[ .Version ]]
-appVersion: [[ .AppVersion ]]
+version: 100.0.0
+appVersion: 100.0.0

--- a/helm/credentiald/templates/credential-default.yaml
+++ b/helm/credentiald/templates/credential-default.yaml
@@ -12,7 +12,9 @@ metadata:
     giantswarm.io/service-type: system
 data:
   {{- if .Values.Installation.V1.Secret.Credentiald.AWS }}
+  {{- if .Values.Installation.V1.Secret.Credentiald.AWS.CredentialDefault.AdminARN }}
   aws.admin.arn: {{ .Values.Installation.V1.Secret.Credentiald.AWS.CredentialDefault.AdminARN | b64enc }}
+  {{- end }}
   aws.awsoperator.arn: {{ .Values.Installation.V1.Secret.Credentiald.AWS.CredentialDefault.AWSOperatorARN | b64enc }}
   {{- end }}
   {{- if .Values.Installation.V1.Secret.Credentiald.Azure }}

--- a/helm/credentiald/templates/credential-default.yaml
+++ b/helm/credentiald/templates/credential-default.yaml
@@ -12,15 +12,13 @@ metadata:
     giantswarm.io/service-type: system
 data:
   {{- if .Values.Installation.V1.Secret.Credentiald.AWS }}
-  {{- if .Values.Installation.V1.Secret.Credentiald.AWS.CredentialDefault.AdminARN }}
-  aws.admin.arn: {{ .Values.Installation.V1.Secret.Credentiald.AWS.CredentialDefault.AdminARN | b64enc }}
-  {{- end }}
-  aws.awsoperator.arn: {{ .Values.Installation.V1.Secret.Credentiald.AWS.CredentialDefault.AWSOperatorARN | b64enc }}
+  aws.admin.arn: {{ .Values.Installation.V1.Secret.Credentiald.AWS.CredentialDefault.AdminARN | b64enc | quote }}
+  aws.awsoperator.arn: {{ .Values.Installation.V1.Secret.Credentiald.AWS.CredentialDefault.AWSOperatorARN | b64enc | quote }}
   {{- end }}
   {{- if .Values.Installation.V1.Secret.Credentiald.Azure }}
-  azure.azureoperator.clientid: {{ .Values.Installation.V1.Secret.Credentiald.Azure.CredentialDefault.ClientID | b64enc }}
-  azure.azureoperator.clientsecret: {{ .Values.Installation.V1.Secret.Credentiald.Azure.CredentialDefault.ClientSecret | b64enc }}
-  azure.azureoperator.subscriptionid: {{ .Values.Installation.V1.Secret.Credentiald.Azure.CredentialDefault.SubscriptionID | b64enc }}
-  azure.azureoperator.tenantid: {{ .Values.Installation.V1.Secret.Credentiald.Azure.CredentialDefault.TenantID | b64enc }}
+  azure.azureoperator.clientid: {{ .Values.Installation.V1.Secret.Credentiald.Azure.CredentialDefault.ClientID | b64enc | quote }}
+  azure.azureoperator.clientsecret: {{ .Values.Installation.V1.Secret.Credentiald.Azure.CredentialDefault.ClientSecret | b64enc | quote }}
+  azure.azureoperator.subscriptionid: {{ .Values.Installation.V1.Secret.Credentiald.Azure.CredentialDefault.SubscriptionID | b64enc | quote }}
+  azure.azureoperator.tenantid: {{ .Values.Installation.V1.Secret.Credentiald.Azure.CredentialDefault.TenantID | b64enc | quote }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Fixing error from helm3 validation. 

```
kg get app credentiald-unique -o yaml | yq .status.release
{
  "lastDeployed": "2020-06-29T12:35:17Z",
  "reason": "Helm reason: Upgrade complete Operator reason: helm validation error: (error validating \"\": error validating data: unknown object type \"nil\" in Secret.data.aws.admin.arn)",
  "status": "validation-failed"
}
```