### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [2.3.0] - 2023-10-03
 
 ### Changed
@@ -56,23 +60,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - No notable changes.
 
-
-
 ## [0.3.0] 2020-05-21
 
 ### Changed
 
 - Deploy as a unique app in app collection
 
-
-
 ## [0.2.0] 2020-04-10
 
 ### Changed
 
 - Migrate from dep to Go modules
-
-
 
 ## [0.1.0] 2020-04-10
 

--- a/helm/credentiald/values.yaml
+++ b/helm/credentiald/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: giantswarm/credentiald
-  tag: [[ .Version ]]
+  tag: [[.Version]]
 deployment:
   replicas: 2
 pod:
@@ -10,7 +10,7 @@ pod:
     id: 1000
 
 registry:
-  domain: docker.io
+  domain: gsoci.azurecr.io
 
 provider:
   aws:


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
